### PR TITLE
Add framework target in project and share it (carthage compatibility)

### DIFF
--- a/AZDialogViewControllerExample/AZDialogViewController/AZDialogViewController.h
+++ b/AZDialogViewControllerExample/AZDialogViewController/AZDialogViewController.h
@@ -1,0 +1,19 @@
+//
+//  AZDialogViewController.h
+//  AZDialogViewController
+//
+//  Created by Eric Marchand on 07/09/2017.
+//  Copyright © 2017 Antonio Zaitoun. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+//! Project version number for AZDialogViewController.
+FOUNDATION_EXPORT double AZDialogViewControllerVersionNumber;
+
+//! Project version string for AZDialogViewController.
+FOUNDATION_EXPORT const unsigned char AZDialogViewControllerVersionString[];
+
+// In this header, you should import all the public headers of your framework using statements like #import <AZDialogViewController/PublicHeader.h>
+
+

--- a/AZDialogViewControllerExample/AZDialogViewController/Info.plist
+++ b/AZDialogViewControllerExample/AZDialogViewController/Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
+</dict>
+</plist>

--- a/AZDialogViewControllerExample/AZDialogViewControllerExample.xcodeproj/project.pbxproj
+++ b/AZDialogViewControllerExample/AZDialogViewControllerExample.xcodeproj/project.pbxproj
@@ -7,6 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		4817E4FD1F61977600066F27 /* AZDialogViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 4817E4FB1F61977600066F27 /* AZDialogViewController.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		4817E5001F61977600066F27 /* AZDialogViewController.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4817E4F91F61977600066F27 /* AZDialogViewController.framework */; };
+		4817E5011F61977600066F27 /* AZDialogViewController.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 4817E4F91F61977600066F27 /* AZDialogViewController.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		4817E5061F61977A00066F27 /* AZDialogViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DDAB3751E639C6F005D257E /* AZDialogViewController.swift */; };
 		9D6F3FE91E62E18000B70203 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D6F3FE81E62E18000B70203 /* AppDelegate.swift */; };
 		9D6F3FEB1E62E18000B70203 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D6F3FEA1E62E18000B70203 /* ViewController.swift */; };
 		9D6F3FEE1E62E18000B70203 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 9D6F3FEC1E62E18000B70203 /* Main.storyboard */; };
@@ -15,7 +19,34 @@
 		9DDAB3761E639C6F005D257E /* AZDialogViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DDAB3751E639C6F005D257E /* AZDialogViewController.swift */; };
 /* End PBXBuildFile section */
 
+/* Begin PBXContainerItemProxy section */
+		4817E4FE1F61977600066F27 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 9D6F3FDD1E62E18000B70203 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 4817E4F81F61977600066F27;
+			remoteInfo = AZDialogViewController;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		4817E5051F61977600066F27 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				4817E5011F61977600066F27 /* AZDialogViewController.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
 /* Begin PBXFileReference section */
+		4817E4F91F61977600066F27 /* AZDialogViewController.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = AZDialogViewController.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		4817E4FB1F61977600066F27 /* AZDialogViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AZDialogViewController.h; sourceTree = "<group>"; };
+		4817E4FC1F61977600066F27 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		9D6F3FE51E62E18000B70203 /* AZDialogViewControllerExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = AZDialogViewControllerExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		9D6F3FE81E62E18000B70203 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		9D6F3FEA1E62E18000B70203 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
@@ -27,21 +58,39 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
-		9D6F3FE21E62E18000B70203 /* Frameworks */ = {
+		4817E4F51F61977600066F27 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		9D6F3FE21E62E18000B70203 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4817E5001F61977600066F27 /* AZDialogViewController.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		4817E4FA1F61977600066F27 /* AZDialogViewController */ = {
+			isa = PBXGroup;
+			children = (
+				4817E4FB1F61977600066F27 /* AZDialogViewController.h */,
+				4817E4FC1F61977600066F27 /* Info.plist */,
+			);
+			path = AZDialogViewController;
+			sourceTree = "<group>";
+		};
 		9D6F3FDC1E62E18000B70203 = {
 			isa = PBXGroup;
 			children = (
 				9DDAB3771E639C8B005D257E /* Source */,
 				9D6F3FE71E62E18000B70203 /* AZDialogViewControllerExample */,
+				4817E4FA1F61977600066F27 /* AZDialogViewController */,
 				9D6F3FE61E62E18000B70203 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -50,6 +99,7 @@
 			isa = PBXGroup;
 			children = (
 				9D6F3FE51E62E18000B70203 /* AZDialogViewControllerExample.app */,
+				4817E4F91F61977600066F27 /* AZDialogViewController.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -77,7 +127,36 @@
 		};
 /* End PBXGroup section */
 
+/* Begin PBXHeadersBuildPhase section */
+		4817E4F61F61977600066F27 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4817E4FD1F61977600066F27 /* AZDialogViewController.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
 /* Begin PBXNativeTarget section */
+		4817E4F81F61977600066F27 /* AZDialogViewController */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 4817E5041F61977600066F27 /* Build configuration list for PBXNativeTarget "AZDialogViewController" */;
+			buildPhases = (
+				4817E4F41F61977600066F27 /* Sources */,
+				4817E4F51F61977600066F27 /* Frameworks */,
+				4817E4F61F61977600066F27 /* Headers */,
+				4817E4F71F61977600066F27 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = AZDialogViewController;
+			productName = AZDialogViewController;
+			productReference = 4817E4F91F61977600066F27 /* AZDialogViewController.framework */;
+			productType = "com.apple.product-type.framework";
+		};
 		9D6F3FE41E62E18000B70203 /* AZDialogViewControllerExample */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 9D6F3FF71E62E18000B70203 /* Build configuration list for PBXNativeTarget "AZDialogViewControllerExample" */;
@@ -85,10 +164,12 @@
 				9D6F3FE11E62E18000B70203 /* Sources */,
 				9D6F3FE21E62E18000B70203 /* Frameworks */,
 				9D6F3FE31E62E18000B70203 /* Resources */,
+				4817E5051F61977600066F27 /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
+				4817E4FF1F61977600066F27 /* PBXTargetDependency */,
 			);
 			name = AZDialogViewControllerExample;
 			productName = AZDialogViewControllerExample;
@@ -105,6 +186,11 @@
 				LastUpgradeCheck = 0820;
 				ORGANIZATIONNAME = "Antonio Zaitoun";
 				TargetAttributes = {
+					4817E4F81F61977600066F27 = {
+						CreatedOnToolsVersion = 8.3.3;
+						DevelopmentTeam = Y759RK5K7D;
+						ProvisioningStyle = Automatic;
+					};
 					9D6F3FE41E62E18000B70203 = {
 						CreatedOnToolsVersion = 8.2.1;
 						DevelopmentTeam = Y759RK5K7D;
@@ -126,11 +212,19 @@
 			projectRoot = "";
 			targets = (
 				9D6F3FE41E62E18000B70203 /* AZDialogViewControllerExample */,
+				4817E4F81F61977600066F27 /* AZDialogViewController */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		4817E4F71F61977600066F27 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		9D6F3FE31E62E18000B70203 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -144,6 +238,14 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		4817E4F41F61977600066F27 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4817E5061F61977A00066F27 /* AZDialogViewController.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		9D6F3FE11E62E18000B70203 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -155,6 +257,14 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		4817E4FF1F61977600066F27 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 4817E4F81F61977600066F27 /* AZDialogViewController */;
+			targetProxy = 4817E4FE1F61977600066F27 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
 		9D6F3FEC1E62E18000B70203 /* Main.storyboard */ = {
@@ -176,6 +286,56 @@
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
+		4817E5021F61977600066F27 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = Y759RK5K7D;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = AZDialogViewController/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 10.3;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = fr.phimage.AZDialogViewController;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		4817E5031F61977600066F27 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = Y759RK5K7D;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = AZDialogViewController/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 10.3;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = fr.phimage.AZDialogViewController;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
 		9D6F3FF51E62E18000B70203 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -270,6 +430,7 @@
 		9D6F3FF81E62E18000B70203 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				DEVELOPMENT_TEAM = Y759RK5K7D;
 				INFOPLIST_FILE = AZDialogViewControllerExample/Info.plist;
@@ -284,6 +445,7 @@
 		9D6F3FF91E62E18000B70203 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				DEVELOPMENT_TEAM = Y759RK5K7D;
 				INFOPLIST_FILE = AZDialogViewControllerExample/Info.plist;
@@ -298,6 +460,14 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		4817E5041F61977600066F27 /* Build configuration list for PBXNativeTarget "AZDialogViewController" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				4817E5021F61977600066F27 /* Debug */,
+				4817E5031F61977600066F27 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+		};
 		9D6F3FE01E62E18000B70203 /* Build configuration list for PBXProject "AZDialogViewControllerExample" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/AZDialogViewControllerExample/AZDialogViewControllerExample.xcodeproj/xcshareddata/xcschemes/AZDialogViewController.xcscheme
+++ b/AZDialogViewControllerExample/AZDialogViewControllerExample.xcodeproj/xcshareddata/xcschemes/AZDialogViewController.xcscheme
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0830"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "4817E4F81F61977600066F27"
+               BuildableName = "AZDialogViewController.framework"
+               BlueprintName = "AZDialogViewController"
+               ReferencedContainer = "container:AZDialogViewControllerExample.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "4817E4F81F61977600066F27"
+            BuildableName = "AZDialogViewController.framework"
+            BlueprintName = "AZDialogViewController"
+            ReferencedContainer = "container:AZDialogViewControllerExample.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "4817E4F81F61977600066F27"
+            BuildableName = "AZDialogViewController.framework"
+            BlueprintName = "AZDialogViewController"
+            ReferencedContainer = "container:AZDialogViewControllerExample.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
Hi, some project settings to make it compatible with carthage
ie. target and shared scheme for the framework

```
carthage build --platform ios
*** xcodebuild output can be found in /var/folders/7p/qlz70z_d0q5137p63hr9092c0000gn/T/carthage-xcodebuild.73omXu.log
*** Building scheme "AZDialogViewController" in AZDialogViewControllerExample.xcodeproj
```